### PR TITLE
Allow relative paths in config file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2023-02-21  Joshua Ulrich  <josh.m.ulrich@gmail.com>
+
+	* R/dequeue.R (dequeueJobs, dequeueDepends): Add relative path support
+	for 'libdir' and 'workdir' arguments
+	* R/enqueue.R (enqueueJobs, enqueueDepends): Idem
+	* R/summarise.R (summariseQueue): Idem
+	* R/utils.R: Update docs to include relative path support for
+	'libdir' and 'workdir' arguments
+	* man/getDataDirectory.Rd: Idem
+
 2022-11-08  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml (jobs): Update to actions/checkout@v3

--- a/R/dequeue.R
+++ b/R/dequeue.R
@@ -42,11 +42,12 @@ dequeueJobs <- function(package, directory, exclude=NULL, date=format(Sys.Date()
         }
         if ("libdir" %in% names(cfg)) {
             ## setting the environment variable works with littler, but not with RScript
-            Sys.setenv("R_LIBS_USER"=cfg$libdir)
-            if (!dir.exists(cfg$libdir)) {
-                dir.create(cfg$libdir)
+            fullLibDir <- normalizePath(cfg$libdir)
+            Sys.setenv("R_LIBS_USER"=fullLibDir)
+            if (!dir.exists(fullLibDir)) {
+                dir.create(fullLibDir)
             }
-            env <- paste0("R_LIBS=\"", cfg$libdir, "\"")
+            env <- paste0("R_LIBS=\"", fullLibDir, "\"")
         }
         if ("verbose" %in% names(cfg)) verbose <- cfg$verbose == "true"
         if ("debug" %in% names(cfg)) debug <- cfg$debug == "true"
@@ -146,10 +147,11 @@ dequeueDepends <- function(package, directory) {
     if (!is.null(cfg <- getConfig())) {
         if ("setup" %in% names(cfg)) source(cfg$setup)
         if ("libdir" %in% names(cfg)) {
-            .libPaths(cfg$libdir)
-            Sys.setenv("R_LIBS_USER"=cfg$libdir)
-            if (!dir.exists(cfg$libdir)) {
-                dir.create(cfg$libdir)
+            fullLibDir <- normalizePath(cfg$libdir)
+            .libPaths(fullLibDir)
+            Sys.setenv("R_LIBS_USER"=fullLibDir)
+            if (!dir.exists(fullLibDir)) {
+                dir.create(fullLibDir)
             }
         }
     }

--- a/R/enqueue.R
+++ b/R/enqueue.R
@@ -21,10 +21,11 @@ enqueueJobs <- function(package, directory, dbfile="", addfailed=FALSE) {
     if (!is.null(cfg <- getConfig())) {
         if ("setup" %in% names(cfg)) source(cfg$setup)
         if ("libdir" %in% names(cfg)) {
-            .libPaths(cfg$libdir)
-            Sys.setenv("R_LIBS_USER"=cfg$libdir)
-            if (!dir.exists(cfg$libdir)) {
-                dir.create(cfg$libdir)
+            fullLibDir <- normalizePath(cfg$libdir)
+            .libPaths(fullLibDir)
+            Sys.setenv("R_LIBS_USER"=fullLibDir)
+            if (!dir.exists(fullLibDir)) {
+                dir.create(fullLibDir)
             }
         }
     }
@@ -93,10 +94,11 @@ enqueueDepends <- function(package, directory) {
     if (!is.null(cfg <- getConfig())) {
         if ("setup" %in% names(cfg)) source(cfg$setup)
         if ("libdir" %in% names(cfg)) {
-            .libPaths(cfg$libdir)
-            Sys.setenv("R_LIBS_USER"=cfg$libdir)
-            if (!dir.exists(cfg$libdir)) {
-                dir.create(cfg$libdir)
+            fullLibDir <- normalizePath(cfg$libdir)
+            .libPaths(fullLibDir)
+            Sys.setenv("R_LIBS_USER"=fullLibDir)
+            if (!dir.exists(fullLibDir)) {
+                dir.create(fullLibDir)
             }
         }
     }

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -127,11 +127,12 @@ summariseQueue <- function(package, directory, dbfile="", extended=FALSE, foghor
         }
         if ("libdir" %in% names(cfg)) {
             ## setting the environment variable works with littler, but not with RScript
-            Sys.setenv("R_LIBS_USER"=cfg$libdir)
-            if (!dir.exists(cfg$libdir)) {
-                dir.create(cfg$libdir)
+            fullLibDir <- normalizePath(cfg$libdir)
+            Sys.setenv("R_LIBS_USER"=fullLibDir)
+            if (!dir.exists(fullLibDir)) {
+                dir.create(fullLibDir)
             }
-            env <- paste0("R_LIBS=\"", cfg$libdir, "\"")
+            env <- paste0("R_LIBS=\"", fullLibDir, "\"")
         }
         if ("verbose" %in% names(cfg)) verbose <- cfg$verbose == "true"
         if ("debug" %in% names(cfg)) debug <- cfg$debug == "true"

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,9 +12,10 @@
 ##' Currently supported are
 ##' \describe{
 ##'   \item{setup}{The path to an R file that will be \code{source}'ed.}
-##'   \item{workdir}{The directory used for the parallel run of reverse depends.}
-##'   \item{libdir}{The directory passed to \code{.libPaths} allow for additonal
-##' build-dependencies.}
+##'   \item{workdir}{The directory used for the parallel run of reverse depends.
+##' May be an absolute or relative path.}
+##'   \item{libdir}{The directory passed to \code{.libPaths} allow for additional
+##' build-dependencies. May be an absolute or relative path. }
 ##'   \item{debug}{A boolean switch to enable more debugging output.}
 ##'   \item{verbose}{A boolean switch to enable more verbose output.}
 ##' }

--- a/man/getDataDirectory.Rd
+++ b/man/getDataDirectory.Rd
@@ -61,9 +61,10 @@ An optional config file can be used to set several configuration variables.
 Currently supported are
 \describe{
   \item{setup}{The path to an R file that will be \code{source}'ed.}
-  \item{workdir}{The directory used for the parallel run of reverse depends.}
-  \item{libdir}{The directory passed to \code{.libPaths} allow for additonal
-build-dependencies.}
+  \item{workdir}{The directory used for the parallel run of reverse depends.
+May be an absolute or relative path.}
+  \item{libdir}{The directory passed to \code{.libPaths} allow for additional
+build-dependencies. May be an absolute or relative path. }
   \item{debug}{A boolean switch to enable more debugging output.}
   \item{verbose}{A boolean switch to enable more verbose output.}
 }


### PR DESCRIPTION
'workdir' could be a relative path, but 'libdir' could not, because `dequeueJobs()` calls `setwd(cfg$workdir)` before running `R CMD check` and that means the 'libdir' relative path is no longer correct.

Use `normalizePath(cfg$libdir)` to get the full library directory path before calling `setwd(cfg$workdir)`.

Fixes #17.